### PR TITLE
Rename project from ecs-deployer ecs-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ECS Deployer
+# ECS Toolkit
 
 ## License
 
@@ -6,5 +6,5 @@
 permissive license that is short and to the point. It lets people do anything
 they want as long as they provide attribution and waive liability.
 
-[license]: https://raw.githubusercontent.com/shipatlas/ecs-deployer/main/LICENSE
+[license]: https://raw.githubusercontent.com/shipatlas/ecs-toolkit/main/LICENSE
 [shipatlas]: https://www.shipatlas.dev

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "ecs-deployer",
+	Use:   "ecs-toolkit",
 	Short: "A brief description of your application",
 	Long: `A longer description that spans multiple lines and likely contains
 examples and usage of using your application. For example:
@@ -41,7 +41,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ecs-deployer.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ecs-toolkit.yaml)")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -58,10 +58,10 @@ func initConfig() {
 		home, err := os.UserHomeDir()
 		cobra.CheckErr(err)
 
-		// Search config in home directory with name ".ecs-deployer" (without extension).
+		// Search config in home directory with name ".ecs-toolkit" (without extension).
 		viper.AddConfigPath(home)
 		viper.SetConfigType("yaml")
-		viper.SetConfigName(".ecs-deployer")
+		viper.SetConfigName(".ecs-toolkit")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shipatlas/ecs-deployer
+module github.com/shipatlas/ecs-toolkit
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/shipatlas/ecs-deployer/cmd"
+import "github.com/shipatlas/ecs-toolkit/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Because toolkit leaves room for it to do more than deploys (which will be it's original use-case).