### PR TITLE
Add version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 SHELL := /bin/bash
 
 BIN_DIR := ./bin
+PACKAGE_PATH := $(shell head -n1 go.mod | cut -d' ' -f2)
+TAG_VERSION := $(tag)
+
+LDFLAGS := -X $(PACKAGE_PATH)/cmd.versionTag=$(TAG_VERSION)
 
 all: dependencies build
 
@@ -9,7 +13,9 @@ dependencies:
 
 build:
 	@mkdir -p ${BIN_DIR}
-	go build -o ${BIN_DIR}
+	go build -ldflags="$(LDFLAGS)" -o ${BIN_DIR}
+	@echo
+	@${BIN_DIR}/ecs-toolkit version
 
 clean:
 	rm -rf ${BIN_DIR}

--- a/README.md
+++ b/README.md
@@ -93,13 +93,15 @@ For normal usage the above instructions should do.
 
 ## License
 
-[ShipAtlas][shipatlas] © 2022. The [MIT License bundled therein][license] is a
-permissive license that is short and to the point. It lets people do anything
-they want as long as they provide attribution and waive liability.
+[King'ori Maina][kingori] © 2022. The [Apache 2.0 License bundled therein][license]
+whose main conditions require preservation of copyright and license notices.
+Contributors provide an express grant of patent rights. Licensed works,
+modifications, and larger works may be distributed under different terms and
+without source code.
 
 [aws-configuration-cli]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html
 [aws-configuration-sdk]: https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/
 [golang-quickstart]: https://go.dev/doc/tutorial/getting-started
 [golangci-lint-install]: https://golangci-lint.run/usage/install/
-[license]: https://raw.githubusercontent.com/shipatlas/ecs-toolkit/main/LICENSE
-[shipatlas]: https://www.shipatlas.dev
+[kingori]: https://kingori.co
+[license]: https://github.com/shipatlas/ecs-toolkit/blob/main/LICENSE.txt

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -54,6 +54,11 @@ var deployCmd = &cobra.Command{
 	Short:   "Deploy an application to AWS ECS.",
 	Long:    deployCmdLong,
 	Example: deployCmdExamples,
+	Args: func(cmd *cobra.Command, args []string) error {
+		err := cobra.NoArgs(cmd, args)
+
+		return err
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		deployCmdOptions.validate()
 		deployCmdOptions.run()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 King'ori Maina
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"runtime/debug"
+	"time"
+
+	"github.com/shipatlas/ecs-toolkit/utils"
+	"github.com/spf13/cobra"
+)
+
+type versionOptions struct {
+	short bool
+}
+
+var (
+	versionCmdLong = utils.LongDesc(`
+		Print out all version information i.e. name, tag, revision, build time etc.`)
+
+	versionCmdExamples = utils.Examples(`
+		# Print out version information
+		ecs-toolkit version
+		
+		# Print out just the version tag
+		ecs-toolkit version --short`)
+
+	versionCmdOptions     = &versionOptions{}
+	versionSourceModified bool
+	versionSourceRevision string
+	versionSourceTime     time.Time
+	versionTag            string
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:     "version",
+	Short:   "Print out version information",
+	Long:    versionCmdLong,
+	Example: versionCmdExamples,
+	Args: func(cmd *cobra.Command, args []string) error {
+		err := cobra.NoArgs(cmd, args)
+
+		return err
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		versionCmdOptions.complete()
+		versionCmdOptions.run()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+
+	// Local flags, which, will be global for the application.
+	versionCmd.Flags().BoolVar(&versionCmdOptions.short, "short", false, "print version tag only")
+}
+
+func (options *versionOptions) complete() {
+	info, _ := debug.ReadBuildInfo()
+
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.modified" && setting.Value == "true" {
+			versionSourceModified = true
+		}
+
+		if setting.Key == "vcs.revision" {
+			versionSourceRevision = setting.Value
+		}
+
+		if setting.Key == "vcs.time" {
+			versionSourceTime, _ = time.Parse(time.RFC3339, setting.Value)
+		}
+	}
+
+	if versionSourceModified {
+		versionSourceRevision = fmt.Sprintf("%s (modified)", versionSourceRevision)
+	}
+
+	if versionTag == "" {
+		versionTag = "(development)"
+	}
+}
+
+func (options *versionOptions) run() {
+	if options.short {
+		fmt.Println(versionTag)
+
+		return
+	}
+
+	fmt.Printf("Name:      %s\n", "ECS Toolkit")
+	fmt.Printf("Version:   %s\n", versionTag)
+	fmt.Printf("Revision:  %s\n", versionSourceRevision)
+	fmt.Printf("Time:      %s\n", versionSourceTime)
+}


### PR DESCRIPTION
Add `version` command to print out version information. See below:

```console
$ make build
go build -ldflags="-X github.com/shipatlas/ecs-toolkit/cmd.versionTag=" -o ./bin
...
...
...

$ ./bin/ecs-toolkit version
Name:      ECS Toolkit
Version:   (development)
Revision:  c7cdd4aac1dd65fb89d68062c5f44658f7ef5665 (modified)
Time:      2022-12-13 18:00:15 +0000 UTC

$ ./bin/ecs-toolkit version --short
(development)
```

```console
$ make build tag=0.1.0  
go build -ldflags="-X github.com/shipatlas/ecs-toolkit/cmd.versionTag=" -o ./bin
...
...
...

$ ./bin/ecs-toolkit version
Name:      ECS Toolkit
Version:   0.1.0
Revision:  c7cdd4aac1dd65fb89d68062c5f44658f7ef5665 (modified)
Time:      2022-12-13 18:00:15 +0000 UTC

$ ./bin/ecs-toolkit version --short
0.1.0
```

### References

* https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies
* https://go.dev/blog/generate
* https://pkg.go.dev/embed
* https://github.com/jasonmf/go-embed-version
* https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
* https://levelup.gitconnected.com/a-better-way-than-ldflags-to-add-a-build-version-to-your-go-binaries-2258ce419d2d
* https://shibumi.dev/posts/go-18-feature/