### PR TITLE
Add ability to generate IAM policy

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 King'ori Maina
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/shipatlas/ecs-toolkit/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	configCmdLong = utils.LongDesc(`
+		Manage configuration files. For more inforation see sub-commands.`)
+)
+
+// configCmd represents the config command
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage configuration files",
+	Long:  configCmdLong,
+	Args: func(cmd *cobra.Command, args []string) error {
+		return cobra.ExactArgs(1)(cmd, args)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+}

--- a/cmd/config_iam_policy.go
+++ b/cmd/config_iam_policy.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 King'ori Maina
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/shipatlas/ecs-toolkit/utils"
+	"github.com/spf13/cobra"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type iamPolicyOptions struct {
+	account string
+	region  string
+}
+
+var (
+	iamPolicyCmdLong = utils.LongDesc(`
+		Generate IAM policy to attach to the IAM role or user.`)
+
+	iamPolicyCmdExamples = utils.Examples(`
+		# Print out generated IAM policy for account 123456789012
+		ecs-toolkit config iam-policy -a 123456789012
+		
+		# Print out generated IAM policy for account 123456789012 and eu-west-1 region
+		ecs-toolkit config iam-policy -a 123456789012 -r eu-west-1`)
+
+	iamPolicyCmdAliases = []string{
+		"policy",
+	}
+
+	iamPolicyCmdOptions = &iamPolicyOptions{}
+)
+
+// iamPolicyCmd represents the version command
+var iamPolicyCmd = &cobra.Command{
+	Use:     "iam-policy",
+	Short:   "Generate IAM policy for use on AWS IAM",
+	Long:    iamPolicyCmdLong,
+	Aliases: iamPolicyCmdAliases,
+	Example: iamPolicyCmdExamples,
+	Args: func(cmd *cobra.Command, args []string) error {
+		err := cobra.NoArgs(cmd, args)
+
+		return err
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		iamPolicyCmdOptions.validate()
+		iamPolicyCmdOptions.run()
+	},
+}
+
+func init() {
+	configCmd.AddCommand(iamPolicyCmd)
+
+	// Local flags, which, will be global for the application.
+	iamPolicyCmd.Flags().StringVarP(&iamPolicyCmdOptions.account, "account", "a", "", "12-digit number that uniquely identifies an AWS account")
+	iamPolicyCmd.Flags().StringVarP(&iamPolicyCmdOptions.region, "region", "r", "us-east-1", "separate geographic areas that AWS uses to house its infrastructure")
+
+	// Configure required flags, applying to this specific command.
+	iamPolicyCmd.MarkFlagRequired("account")
+}
+
+func (options *iamPolicyOptions) validate() {
+	if options.account == "" {
+		log.Fatal("account flag must be set and should not be blank")
+	}
+
+	if options.region == "" {
+		log.Fatal("region flag must be set and should not be blank")
+	}
+}
+
+func (options *iamPolicyOptions) run() {
+	policy, err := toolConfig.GenerateIAMPolicy(options.account, options.region)
+	if err != nil {
+		log.Fatal("error generating IAM policy, exiting!")
+	}
+
+	fmt.Println(policy)
+}

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -64,3 +64,12 @@ func (config *Config) ServiceNames() []string {
 
 	return serviceNames
 }
+
+func (config *Config) TaskFamilies() []string {
+	taskFamilies := []string{}
+	for _, task := range config.Tasks {
+		taskFamilies = append(taskFamilies, *task.Family)
+	}
+
+	return taskFamilies
+}

--- a/pkg/iam_policy.go
+++ b/pkg/iam_policy.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 King'ori Maina
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type PolicyDocument struct {
+	Version   string           `json:"Version"`
+	Statement []StatementEntry `json:"Statement"`
+}
+
+type StatementEntry struct {
+	Sid      string      `json:"Sid"`
+	Effect   string      `json:"Effect"`
+	Action   interface{} `json:"Action"`
+	Resource interface{} `json:"Resource"`
+}
+
+func (config *Config) GenerateIAMPolicy(account, region string) (string, error) {
+	var (
+		serviceArns               []string
+		serviceNames              []string
+		serviceTaskDefinitionArns []string
+		taskFamilies              []string
+		taskTaskDefinitionArns    []string
+	)
+
+	serviceNames = config.ServiceNames()
+	taskFamilies = config.TaskFamilies()
+
+	for _, serviceName := range serviceNames {
+		serviceArn := fmt.Sprintf("arn:aws:ecs:%s:%s:service/%s/%s", region, account, *config.Cluster, serviceName)
+		serviceArns = append(serviceArns, serviceArn)
+	}
+
+	for _, serviceName := range serviceNames {
+		taskDefinitionFamilyArn := fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s:*", region, account, serviceName)
+		serviceTaskDefinitionArns = append(serviceTaskDefinitionArns, taskDefinitionFamilyArn)
+	}
+
+	for _, taskFamily := range taskFamilies {
+		taskDefinitionFamilyArn := fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s:*", region, account, taskFamily)
+		taskTaskDefinitionArns = append(taskTaskDefinitionArns, taskDefinitionFamilyArn)
+	}
+
+	taskDefinitionFamilyArns := append(serviceTaskDefinitionArns, taskTaskDefinitionArns...)
+
+	policy := PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []StatementEntry{
+			StatementEntry{
+				Sid:    "AccessServices",
+				Effect: "Allow",
+				Action: []string{
+					"ecs:DescribeServices",
+					"ecs:UpdateService",
+				},
+				Resource: serviceArns,
+			},
+			StatementEntry{
+				Sid:    "AccessTaskDefinitions",
+				Effect: "Allow",
+				Action: []string{
+					"ecs:DescribeTaskDefinition",
+					"ecs:RegisterTaskDefinition",
+				},
+				Resource: taskDefinitionFamilyArns,
+			},
+			StatementEntry{
+				Sid:      "AccessTasks",
+				Effect:   "Allow",
+				Action:   "ecs:DescribeTasks",
+				Resource: fmt.Sprintf("arn:aws:ecs:%s:%s:task/%s/*", region, account, *config.Cluster),
+			},
+			StatementEntry{
+				Sid:      "RunTasks",
+				Effect:   "Allow",
+				Action:   "ecs:RunTask",
+				Resource: taskTaskDefinitionArns,
+			},
+		},
+	}
+
+	policyBytes, err := json.MarshalIndent(&policy, "", "  ")
+	if err != nil {
+		log.Errorf("error marshaling policy: %v", err)
+
+		return "", err
+	}
+
+	return string(policyBytes), nil
+}


### PR DESCRIPTION
For example if you have a config that looks like this:

```yaml
---
version: v1
cluster: example
tasks:
  - family: app-asset-sync
    count: 1
    containers:
      - rails
    launch_type: fargate
    network_configuration: 
      vpc_configuration:
        assign_public_ip: true
        security_groups:
          - sg-xxxxxxxxxxxxxxxxx
        subnets:
          - subnet-xxxxxxxxxxxxxxxxx
  - family: app-database-migrate
    count: 1
    containers:
      - rails
    launch_type: ec2
services:
  - name: app-web-server
    containers:
      - rails
  - name: app-worker
    containers:
      - resque
  - name: app-worker-scheduler
    containers:
      - resque-scheduler
```

And you want a policy that works with resources in account `123456789012` and in the `eu-west-1` region, you can generate a restricted policy like this:

```console
$ ./bin/ecs-toolkit --log-level=debug config iam-policy -a 123456789012 -r eu-west-1
DEBU[0000] log level set to debug                       
INFO[0000] using config file: .ecs-toolkit.yml          
INFO[0000] reading .ecs-toolkit.yml config file         
DEBU[0000] parsing .ecs-toolkit.yml config file         
DEBU[0000] validating .ecs-toolkit.yml config file      
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "AccessServices",
      "Effect": "Allow",
      "Action": [
        "ecs:DescribeServices",
        "ecs:UpdateService"
      ],
      "Resource": [
        "arn:aws:ecs:eu-west-1:123456789012:service/example/app-web-server",
        "arn:aws:ecs:eu-west-1:123456789012:service/example/app-worker",
        "arn:aws:ecs:eu-west-1:123456789012:service/example/app-worker-scheduler"
      ]
    },
    {
      "Sid": "AccessTaskDefinitions",
      "Effect": "Allow",
      "Action": [
        "ecs:DescribeTaskDefinition",
        "ecs:RegisterTaskDefinition"
      ],
      "Resource": [
        "arn:aws:ecs:eu-west-1:123456789012:task-definition/app-web-server:*",
        "arn:aws:ecs:eu-west-1:123456789012:task-definition/app-worker:*",
        "arn:aws:ecs:eu-west-1:123456789012:task-definition/app-worker-scheduler:*",
        "arn:aws:ecs:eu-west-1:123456789012:task-definition/app-asset-sync:*",
        "arn:aws:ecs:eu-west-1:123456789012:task-definition/app-database-migrate:*"
      ]
    },
    {
      "Sid": "AccessTasks",
      "Effect": "Allow",
      "Action": "ecs:DescribeTasks",
      "Resource": "arn:aws:ecs:eu-west-1:123456789012:task/example/*"
    },
    {
      "Sid": "RunTasks",
      "Effect": "Allow",
      "Action": "ecs:RunTask",
      "Resource": [
        "arn:aws:ecs:eu-west-1:123456789012:task-definition/app-asset-sync:*",
        "arn:aws:ecs:eu-west-1:123456789012:task-definition/app-database-migrate:*"
      ]
    }
  ]
}
```