### PR TITLE
Prepare for release: add HoundCI, contributing, codeowners and GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    tags:
+      - "[0-9].[0-9]+.[0-9]+"
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set the version
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: Version ${{ env.VERSION }}
+          draft: false
+          prerelease: false

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+---
+go:
+  enabled: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @itskingori

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Development
+
+Below instructions are only necessary if you intend to work on the source code.
+For normal usage the above instructions should do.
+
+### Requirements
+
+1. Ensure that you have a [properly configured][golang-quickstart] Go workspace.
+
+### Building
+
+1. Clone the repository.
+2. Fetch the dependencies with `go get -v github.com/shipatlas/ecs-toolkit`.
+4. Install application dependencies via `make dependencies` (they'll be placed
+   in `./vendor`).
+5. Build and install the binary with `make build`.
+6. Run the command e.g. `./bin/ecs-toolkit help` as a basic test.
+
+### Testing
+
+1. Install the `golangci-lint`, [see instructions here][golangci-lint-install].
+2. Run linter using `make lint` and test using `make test`.
+
+[golang-quickstart]: https://go.dev/doc/tutorial/getting-started
+[golangci-lint-install]: https://golangci-lint.run/usage/install/

--- a/README.md
+++ b/README.md
@@ -361,29 +361,6 @@ WARN[0016] skipping rollout of post-deployment tasks, none found  cluster=exampl
 
 For more information see `ecs-toolkit --help` or `ecs-toolkit <command> --help`.
 
-## Development
-
-Below instructions are only necessary if you intend to work on the source code.
-For normal usage the above instructions should do.
-
-### Requirements
-
-1. Ensure that you have a [properly configured][golang-quickstart] Go workspace.
-
-### Building
-
-1. Clone the repository.
-2. Fetch the dependencies with `go get -v github.com/shipatlas/ecs-toolkit`.
-4. Install application dependencies via `make dependencies` (they'll be placed
-   in `./vendor`).
-5. Build and install the binary with `make build`.
-6. Run the command e.g. `./bin/ecs-toolkit help` as a basic test.
-
-### Testing
-
-1. Install the `golangci-lint`, [see instructions here][golangci-lint-install].
-2. Run linter using `make lint` and test using `make test`.
-
 ## Inspiration
 
 * https://github.com/aws/amazon-ecs-cli
@@ -405,8 +382,6 @@ without source code.
 [aws-ecr-register-tf]: https://docs.aws.amazon.com/cli/latest/reference/ecs/register-task-definition.html
 [aws-ecs-cli]: https://github.com/aws/amazon-ecs-cli
 [aws-fargate-cli]: https://github.com/awslabs/fargatecli
-[golang-quickstart]: https://go.dev/doc/tutorial/getting-started
-[golangci-lint-install]: https://golangci-lint.run/usage/install/
 [kingori]: https://kingori.co
 [license]: https://github.com/shipatlas/ecs-toolkit/blob/main/LICENSE.txt
 [new-issue]: https://github.com/shipatlas/ecs-toolkit/issues/new


### PR DESCRIPTION
### References

* http://help.houndci.com/en/
* http://help.houndci.com/en/articles/2138524-golint
* https://dev.to/koddr/github-action-for-release-your-go-projects-as-fast-and-easily-as-possible-20a2
* https://fabianlee.org/2022/11/20/github-automated-github-release-of-golang-binary-using-github-actions/
* https://www.alexedwards.net/blog/ci-with-go-and-github-actions