### PR TITLE
Remove source modification info from version command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.0
+## 0.1.0
 
 First prototype of the idea with deploy feature. Takes inputs as a config file
 which allows you to:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+* Remove source modification info from `version` command.
+
 ## 0.1.0
 
 First prototype of the idea with deploy feature. Takes inputs as a config file

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -75,10 +75,6 @@ func (options *versionOptions) complete() {
 	info, _ := debug.ReadBuildInfo()
 
 	for _, setting := range info.Settings {
-		if setting.Key == "vcs.modified" && setting.Value == "true" {
-			versionSourceModified = true
-		}
-
 		if setting.Key == "vcs.revision" {
 			versionSourceRevision = setting.Value
 		}
@@ -86,10 +82,6 @@ func (options *versionOptions) complete() {
 		if setting.Key == "vcs.time" {
 			versionSourceTime, _ = time.Parse(time.RFC3339, setting.Value)
 		}
-	}
-
-	if versionSourceModified {
-		versionSourceRevision = fmt.Sprintf("%s (modified)", versionSourceRevision)
 	}
 
 	if versionTag == "" {


### PR DESCRIPTION
Because it's not useful.

**Before**

```console
$ ./ecs-toolkit version
Name:      ECS Toolkit
Version:   0.1.0
Revision:  5b3a51b77ef445e5902c4ae29b848bc11dd7f46c (modified)
```

**After**

```console
$ ./bin/ecs-toolkit version
Name:      ECS Toolkit
Version:   0.2.0
Revision:  5b3a51b77ef445e5902c4ae29b848bc11dd7f46c
Time:      2022-12-21 12:53:38 +0000 UTC
```