### PR TITLE
Fix runtime panic when watching task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 0.2.1
+
+* Fix runtime panic when watching task - https://github.com/shipatlas/ecs-toolkit/pull/30.
+
 ## 0.2.0
 
-* Remove source modification info from `version` command.
+* Remove source modification info from `version` command - https://github.com/shipatlas/ecs-toolkit/pull/28.
 
 ## 0.1.0
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -41,7 +41,6 @@ var (
 		ecs-toolkit version --short`)
 
 	versionCmdOptions     = &versionOptions{}
-	versionSourceModified bool
 	versionSourceRevision string
 	versionSourceTime     time.Time
 	versionTag            string


### PR DESCRIPTION
Make sure the pointers aren't nil before dereferencing them thus handling the panic.