### PR TITLE
Fix error deploying service exit when services are skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,26 @@
 # Changelog
 
+## 0.2.2
+
+* **Fixes**
+  * Fix error deploying service exit when services are skipped.
+  * Fix incorrect EnableExecuteCommand setting update.
+* **Pull Requests**
+  * https://github.com/shipatlas/ecs-toolkit/pull/31
+
 ## 0.2.1
 
-* Fix runtime panic when watching task - https://github.com/shipatlas/ecs-toolkit/pull/30.
+* **Fixes**
+  * Fix runtime panic when watching task.
+* **Pull Requests**
+  * https://github.com/shipatlas/ecs-toolkit/pull/30
 
 ## 0.2.0
 
-* Remove source modification info from `version` command - https://github.com/shipatlas/ecs-toolkit/pull/28.
+* **Changes**
+  * Remove source modification info from `version` command.
+* **Pull Requests**
+  * https://github.com/shipatlas/ecs-toolkit/pull/28
 
 ## 0.1.0
 

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -139,7 +139,7 @@ func deployService(cluster *string, serviceConfig *Service, newContainerImageTag
 		DeploymentConfiguration:       service.DeploymentConfiguration,
 		DesiredCount:                  &service.DesiredCount,
 		EnableECSManagedTags:          &service.EnableECSManagedTags,
-		EnableExecuteCommand:          &service.EnableECSManagedTags,
+		EnableExecuteCommand:          &service.EnableExecuteCommand,
 		HealthCheckGracePeriodSeconds: service.HealthCheckGracePeriodSeconds,
 		LoadBalancers:                 service.LoadBalancers,
 		NetworkConfiguration:          service.NetworkConfiguration,

--- a/pkg/status.go
+++ b/pkg/status.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2023 King'ori Maina
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+type Status string
+
+const (
+	FailedStatus    Status = "failed"
+	SkippedStatus   Status = "skipped"
+	SucceededStatus Status = "succeeded"
+)


### PR DESCRIPTION
Avoid reporting skipped services as an error, which can happen if the services hasn't yet been created. For example:

```
time="2023-05-01T01:18:44Z" level=info msg="services report - total: 3, successful: 1, failed: 2" cluster=shipatlas
time="2023-05-01T01:18:44Z" level=fatal msg="error deploying services, exiting!"
Error: Process completed with exit code 1.
```